### PR TITLE
Configurable timings for automated actions (#12)

### DIFF
--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultGuildSettingsService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultGuildSettingsService.kt
@@ -43,6 +43,8 @@ class DefaultGuildSettingsService(
             devGuild = settings.devGuild,
             patronGuild = settings.patronGuild,
             useProjects = settings.useProjects,
+            autoCloseHours = settings.autoClose.toHours().toInt(),
+            autoDeleteHours = settings.autoDelete.toHours().toInt(),
             requiresRepair = settings.requiresRepair,
 
             awaitingCategory = settings.awaitingCategory?.asLong(),
@@ -67,6 +69,8 @@ class DefaultGuildSettingsService(
             devGuild = settings.devGuild,
             patronGuild = settings.patronGuild,
             useProjects = settings.useProjects,
+            autoCloseHours = settings.autoClose.toHours().toInt(),
+            autoDeleteHours = settings.autoDelete.toHours().toInt(),
             requiresRepair = settings.requiresRepair,
 
             awaitingCategory = settings.awaitingCategory?.asLong(),

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultStaticMessageService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultStaticMessageService.kt
@@ -71,6 +71,7 @@ class DefaultStaticMessageService(
     }
 
     override suspend fun update(guildId: Snowflake): Message? {
+
         val settings = settingsService.getGuildSettings(guildId)
 
         // Cannot run if support channel or static message not set

--- a/src/main/kotlin/org/dreamexposure/ticketbird/command/SetupCommand.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/command/SetupCommand.kt
@@ -38,6 +38,7 @@ class SetupCommand(
             "repair" -> repair(event, settings)
             "language" -> language(event, settings)
             "use-projects" -> useProjects(event, settings)
+            "timing" -> timing(event, settings)
             else -> throw IllegalStateException("Invalid subcommand specified")
         }
     }
@@ -150,5 +151,9 @@ class SetupCommand(
         return event.createFollowup(localeService.getString(settings.locale, "command.setup.use-projects.success.$useProjects"))
             .withEphemeral(ephemeral)
             .awaitSingle()
+    }
+
+    private suspend fun timing(event: ChatInputInteractionEvent, settings: GuildSettings): Message {
+        TODO("Not yet implemented")
     }
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/command/SetupCommand.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/command/SetupCommand.kt
@@ -47,7 +47,7 @@ class SetupCommand(
 
     private suspend fun init(event: ChatInputInteractionEvent, settings: GuildSettings): Message {
         // check if setup has already been done
-        if (settings.supportChannel != null) {
+        if (!settings.hasRequiredIdsSet() && !settings.requiresRepair) {
             return event.createFollowup(localeService.getString(settings.locale, "command.setup.init.already"))
                 .withEphemeral(ephemeral)
                 .awaitSingle()
@@ -182,6 +182,11 @@ class SetupCommand(
         when (action) {
             "auto-close" -> settings.autoClose = days + hours
             "auto-delete" -> settings.autoDelete = days + hours
+            else -> {
+                return event.createFollowup(
+                    localeService.getString(settings.locale, "command.setup.timing.error.action-not-found")
+                ).withEphemeral(ephemeral).awaitSingle()
+            }
         }
 
         settingsService.createOrUpdateGuildSettings(settings)

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsData.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsData.kt
@@ -13,6 +13,8 @@ data class GuildSettingsData(
     val devGuild: Boolean,
 
     val useProjects: Boolean,
+    val autoCloseHours: Int,
+    val autoDeleteHours: Int,
 
     val requiresRepair: Boolean,
 

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsRepository.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsRepository.kt
@@ -13,6 +13,8 @@ interface GuildSettingsRepository: R2dbcRepository<GuildSettingsData, Long> {
             patron_guild = :patronGuild,
             dev_guild = :devGuild,
             use_projects = :useProjects,
+            auto_close_hours = :autoCloseHours,
+            auto_delete_hours = :autoDeleteHours,
             requires_repair = :requiresRepair,
             awaiting_category = :awaitingCategory,
             responded_category = :respondedCategory,
@@ -30,6 +32,8 @@ interface GuildSettingsRepository: R2dbcRepository<GuildSettingsData, Long> {
         patronGuild: Boolean,
         devGuild: Boolean,
         useProjects: Boolean,
+        autoCloseHours: Int,
+        autoDeleteHours: Int,
         requiresRepair: Boolean,
 
         awaitingCategory: Long?,

--- a/src/main/kotlin/org/dreamexposure/ticketbird/extensions/Duration.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/extensions/Duration.kt
@@ -8,7 +8,11 @@ fun Duration.getHumanReadable() =
 fun Duration.getHumanReadableMinimized(): String {
     val builder = StringBuilder()
 
-    if (toDays() > 0) builder.append("${toDays()} days")
-    if (toHoursPart() > 0) builder.append(", ${toHoursPart()} hours")
+    if (toDays() == 1L) builder.append("${toDays()} day")
+    if (toDays() >= 2L) builder.append("${toDays()} days")
+
+    if (toHoursPart() == 1) builder.append(", ${toHoursPart()} hour")
+    if (toHoursPart() >= 2) builder.append(", ${toHoursPart()} hours")
+
     return builder.toString()
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/extensions/Duration.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/extensions/Duration.kt
@@ -4,3 +4,11 @@ import java.time.Duration
 
 fun Duration.getHumanReadable() =
     "%d d, %d h, %d m, %d s%n".format(toDays(), toHoursPart(), toMinutesPart(), toSecondsPart())
+
+fun Duration.getHumanReadableMinimized(): String {
+    val builder = StringBuilder()
+
+    if (toDays() > 0) builder.append("${toDays()} days")
+    if (toHoursPart() > 0) builder.append(", ${toHoursPart()} hours")
+    return builder.toString()
+}

--- a/src/main/kotlin/org/dreamexposure/ticketbird/interaction/SetupTimingsAutoComplete.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/interaction/SetupTimingsAutoComplete.kt
@@ -1,0 +1,52 @@
+package org.dreamexposure.ticketbird.interaction
+
+import discord4j.core.event.domain.interaction.ChatInputAutoCompleteEvent
+import discord4j.core.`object`.command.ApplicationCommandInteractionOptionValue
+import discord4j.discordjson.json.ApplicationCommandOptionChoiceData
+import kotlinx.coroutines.reactor.awaitSingleOrNull
+import org.dreamexposure.ticketbird.business.LocaleService
+import org.dreamexposure.ticketbird.extensions.getHumanReadableMinimized
+import org.dreamexposure.ticketbird.`object`.GuildSettings
+import org.springframework.stereotype.Component
+
+@Component
+class SetupTimingsAutoComplete(
+    private val localeService: LocaleService,
+) : InteractionHandler<ChatInputAutoCompleteEvent> {
+    override val ids = arrayOf("setup.action")
+
+    override suspend fun handle(event: ChatInputAutoCompleteEvent, settings: GuildSettings) {
+        when ("${event.commandName}.${event.focusedOption.name}") {
+            "setup.action" -> actionTiming(event, settings)
+            else -> event.respondWithSuggestions(listOf()).awaitSingleOrNull()
+        }
+    }
+
+    private suspend fun actionTiming(event: ChatInputAutoCompleteEvent, settings: GuildSettings) {
+        val input = event.focusedOption.value
+            .map(ApplicationCommandInteractionOptionValue::asString)
+            .get()
+
+        val actions = listOf(
+            ApplicationCommandOptionChoiceData.builder()
+                .name(localeService.getString(
+                    settings.locale,
+                    "auto-complete.setup.actions.auto-close",
+                    settings.autoClose.getHumanReadableMinimized()
+                )).value("auto-close")
+                .build(),
+            ApplicationCommandOptionChoiceData.builder()
+                .name(localeService.getString(
+                    settings.locale,
+                    "auto-complete.setup.actions.auto-delete",
+                    settings.autoDelete.getHumanReadableMinimized()
+                )).value("auto-delete")
+                .build()
+        )
+        val filtered = actions.filter { it.name().contains(input) || (it.value() as String).contains(input) }
+
+        event.respondWithSuggestions(filtered.ifEmpty { actions })
+            .awaitSingleOrNull()
+    }
+}
+

--- a/src/main/kotlin/org/dreamexposure/ticketbird/listeners/TextChannelDeleteListener.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/listeners/TextChannelDeleteListener.kt
@@ -1,0 +1,25 @@
+package org.dreamexposure.ticketbird.listeners
+
+import discord4j.core.event.domain.channel.TextChannelDeleteEvent
+import org.dreamexposure.ticketbird.business.GuildSettingsService
+import org.springframework.stereotype.Component
+
+@Component
+class TextChannelDeleteListener(
+    private val settingsService: GuildSettingsService,
+): EventListener<TextChannelDeleteEvent> {
+    override suspend fun handle(event: TextChannelDeleteEvent) {
+        val settings = settingsService.getGuildSettings(event.channel.guildId)
+
+        when (event.channel.id) {
+            settings.supportChannel -> {
+                settings.supportChannel = null
+                settings.staticMessage = null // If channel is deleted, so are all messages in it
+                settings.requiresRepair = true
+            } else -> return // Not a channel we care about
+        }
+
+        // If we made it here, we should update the settings
+        settingsService.createOrUpdateGuildSettings(settings)
+    }
+}

--- a/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
@@ -5,6 +5,7 @@ import org.dreamexposure.ticketbird.database.GuildSettingsData
 import org.dreamexposure.ticketbird.extensions.handleLocaleDebt
 import org.dreamexposure.ticketbird.extensions.listFromDb
 import org.dreamexposure.ticketbird.extensions.toSnowflake
+import java.time.Duration
 import java.util.*
 import java.util.concurrent.CopyOnWriteArrayList
 
@@ -13,7 +14,11 @@ data class GuildSettings(
     var locale: Locale = Locale.ENGLISH,
     var patronGuild: Boolean = false,
     var devGuild: Boolean = false,
+
     var useProjects: Boolean = false,
+    val autoClose: Duration = Duration.ofDays(7),
+    val autoDelete: Duration = Duration.ofHours(24),
+
     var requiresRepair: Boolean = false,
 
     var awaitingCategory: Snowflake? = null,
@@ -31,6 +36,10 @@ data class GuildSettings(
         locale = data.lang.handleLocaleDebt(),
         patronGuild = data.patronGuild,
         useProjects = data.useProjects,
+        autoClose = Duration.ofHours(data.autoCloseHours.toLong()),
+        autoDelete = Duration.ofHours(data.autoDeleteHours.toLong()),
+
+
         requiresRepair = data.requiresRepair,
 
         awaitingCategory = data.awaitingCategory?.toSnowflake(),

--- a/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
@@ -16,8 +16,8 @@ data class GuildSettings(
     var devGuild: Boolean = false,
 
     var useProjects: Boolean = false,
-    val autoClose: Duration = Duration.ofDays(7),
-    val autoDelete: Duration = Duration.ofHours(24),
+    var autoClose: Duration = Duration.ofDays(7),
+    var autoDelete: Duration = Duration.ofHours(24),
 
     var requiresRepair: Boolean = false,
 

--- a/src/main/kotlin/org/dreamexposure/ticketbird/service/ActivityMonitor.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/service/ActivityMonitor.kt
@@ -71,7 +71,7 @@ class ActivityMonitor(
                     // Loop closed tickets
                     for (closedTicketChannel in closedCategoryChannels) {
                         val ticket = ticketService.getTicket(guild.id, closedTicketChannel.id)
-                        if (ticket != null && Duration.between(Instant.now(), ticket.lastActivity).abs() > Duration.ofDays(1)) {
+                        if (ticket != null && Duration.between(Instant.now(), ticket.lastActivity).abs() > settings.autoDelete) {
                             // Ticket closed for over 24 hours, purge
                             ticketService.purgeTicket(settings.guildId, ticket.channel)
                         }
@@ -81,7 +81,7 @@ class ActivityMonitor(
                     for (openTicketChannel in awaitingCategoryChannels + respondedCategoryChannels) {
                         val ticket = ticketService.getTicket(guild.id, openTicketChannel.id)
 
-                        if (ticket != null && Duration.between(Instant.now(), ticket.lastActivity).abs() > Duration.ofDays(7)) {
+                        if (ticket != null && Duration.between(Instant.now(), ticket.lastActivity).abs() > settings.autoClose) {
                             // Inactive, auto-close
                             ticketService.closeTicket(settings.guildId, ticket.channel, inactive = true)
                         }

--- a/src/main/resources/commands/setup.json
+++ b/src/main/resources/commands/setup.json
@@ -45,6 +45,43 @@
           "required": true
         }
       ]
+    },
+    {
+      "type": 1,
+      "name": "timing",
+      "description": "Allows changing timings for the various automatic actions performed by TicketBird",
+      "options": [
+        {
+          "type": 3,
+          "name": "action",
+          "description": "The action you want to change the timing of",
+          "required": true,
+          "choices": [
+            {
+              "name": "Auto Close Ticket (default: 7 days)",
+              "value": "auto-close"
+            },
+            {
+              "name": "Auto Delete Closed Ticket (default: 24 hours)",
+              "value": "auto-delete"
+            }
+          ]
+        },
+        {
+          "type": 4,
+          "name": "days",
+          "description": "Amount of days (added to hours; default: 0)",
+          "min_value": 0,
+          "max_value": 30
+        },
+        {
+          "type": 4,
+          "name": "hours",
+          "description": "Amount of hours (added to days; default: 0)",
+          "min_value": 0,
+          "max_value": 999
+        }
+      ]
     }
   ]
 }

--- a/src/main/resources/commands/setup.json
+++ b/src/main/resources/commands/setup.json
@@ -56,16 +56,7 @@
           "name": "action",
           "description": "The action you want to change the timing of",
           "required": true,
-          "choices": [
-            {
-              "name": "Auto Close Ticket (default: 7 days)",
-              "value": "auto-close"
-            },
-            {
-              "name": "Auto Delete Closed Ticket (default: 24 hours)",
-              "value": "auto-delete"
-            }
-          ]
+          "autocomplete": true
         },
         {
           "type": 4,

--- a/src/main/resources/db/migration/V12__Add_Configurable_AutoClose.sql
+++ b/src/main/resources/db/migration/V12__Add_Configurable_AutoClose.sql
@@ -1,0 +1,7 @@
+ALTER TABLE guild_settings
+    ADD COLUMN auto_close_hours INT NOT NULL DEFAULT 168 -- 1 week
+        AFTER use_projects;
+
+ALTER TABLE guild_settings
+    ADD COLUMN auto_delete_hours INT NOT NULL DEFAULT 24 -- 1 day
+        AFTER auto_close_hours;

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -113,6 +113,9 @@ command.setup.use-projects.success.true=Successfully enabled projects! \
   Use `/project add` to add a new project.
 command.setup.use-projects.success.false=Successfully disabled projects!\
   Users will not need to select a project when opening a ticket. Existing projects and tickets will not be modified.
+command.setup.timing.error.duration-zero=This timing cannot be set to 0. Make sure it's set to at least 1 hour.
+command.setup.timing.success.auto-close=Tickets will now be automatically closed after {0} of inactivity.
+command.setup.timing.success.auto-delete=Closed tickets will now be automatically deleted after {0}.
 command.setup.init.already=TicketBird has already been initialized. You do not need to run this command again. \n\n\
   If you accidentally deleted a category or the support channel, you can use `/setup repair`
 command.setup.init.success=TicketBird Setup Complete! \n\

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -83,6 +83,10 @@ modal.ticket-detail.info.label=Additional Info
 modal.ticket-detail.info.placeholder=Any additional info you'd like to add. \
   Such as a description of an error, version numbers, etc.
 
+# Auto complete
+auto-complete.setup.actions.auto-close=Auto Close Ticket (Current: {0})
+auto-complete.setup.actions.auto-delete=Auto Delete Closed Ticket (Current: {0})
+
 # Commands
 command.dm-not-supported=Commands not supported in DMs.
 
@@ -114,6 +118,7 @@ command.setup.use-projects.success.true=Successfully enabled projects! \
 command.setup.use-projects.success.false=Successfully disabled projects!\
   Users will not need to select a project when opening a ticket. Existing projects and tickets will not be modified.
 command.setup.timing.error.duration-zero=This timing cannot be set to 0. Make sure it's set to at least 1 hour.
+command.setup.timing.error.action-not-found=An action with that name was not found. Perhaps there was a typo?
 command.setup.timing.success.auto-close=Tickets will now be automatically closed after {0} of inactivity.
 command.setup.timing.success.auto-delete=Closed tickets will now be automatically deleted after {0}.
 command.setup.init.already=TicketBird has already been initialized. You do not need to run this command again. \n\n\


### PR DESCRIPTION
Adds new `/setup timing` command for configuring automated timings (right now, just auto close inactive tickets and auto-delete closed tickets). This command uses auto-complete for showing what can be edited, and the current setting.

Also fix a few bugs and polish surrounding features