### PR TITLE
Implement staff RBAC 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Perfect for modmail, community management, and more, TicketBird is capable of al
 - Won't disrupt your community. TicketBird will not affect anything beyond the channels it manages for tickets.
 - Auto-close tickets after 7 days of inactivity, and auto-delete tickets after being closed for 24 hours (fully configurable)
 - Place tickets on hold until you can get to them; so they don't auto-close
-- Set staff per project/topic using the `/project edit` command.
+- Set staff per project/topic using the `/project edit` command
   - This allows you to define a user or role as staff for only a specific ticket type, allowing further customization similar to traditional RBAC.
+- Ping specific staff members and roles when a new ticket is opened
+  - Can be overridden on a project-level basis
 
 ## ⌨️ Commands
 | Command             | Description                                                                               | Permissions |
@@ -50,7 +52,6 @@ Perfect for modmail, community management, and more, TicketBird is capable of al
 This bot is a hobby project for me, please note that while these features are planned, there's no solid timeline.
 - Website rewrite (It's old and ugly)
 - Customizable messages
-- Toggle to ping staff when new ticket is opened
 - And so much more!
 
 # 🧰 Tech stack

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/DreamExposure/TicketBird-Discord-Bot/Java%20CI?label=Build&style=flat-square)
 [![Website](https://img.shields.io/website?down_color=red&down_message=offline&label=Status&style=flat-square&up_message=online&url=https%3A%2F%2Fticketbird.dreamexposure.org)](https://ticketbird.dreamexposure.org)
 
-TicketBird is a simple help desk and ticket managing Discord bot allowing you to run a simple help desk system within your Discord server.
+TicketBird is a simple help desk and ticket managing Discord bot allowing you to run a simple help desk system within your Discord server. 
+Perfect for modmail, community management, and more, TicketBird is capable of all your ticketing needs!
 
 # 🔗 Quick Links
 - [Invite](https://discord.com/oauth2/authorize?client_id=456140067220750336&permissions=395405945880&scope=bot+applications.commands)
@@ -12,11 +13,14 @@ TicketBird is a simple help desk and ticket managing Discord bot allowing you to
 
 # 💎 Core Features
 - Simple setup (just use one command to get everything initiated)
+- Easy to repair. Accidentally delete a channel? No worries, TicketBird is always watching for changes and ready to repair itself via a single command!
 - Easy for users to understand and use without a single command (but can also open tickets with a command)
 - Allow users to pick from up to 25 topics (called projects), if desired
 - Won't disrupt your community. TicketBird will not affect anything beyond the channels it manages for tickets.
 - Auto-close tickets after 7 days of inactivity, and auto-delete tickets after being closed for 24 hours (fully configurable)
 - Place tickets on hold until you can get to them; so they don't auto-close
+- Set staff per project/topic using the `/project edit` command.
+  - This allows you to define a user or role as staff for only a specific ticket type, allowing further customization similar to traditional RBAC.
 
 ## ⌨️ Commands
 | Command             | Description                                                             | Permissions |
@@ -37,14 +41,14 @@ TicketBird is a simple help desk and ticket managing Discord bot allowing you to
 | /project add        | Adds a new "project" or ticket category/topic to aid with sorting       | Admin-only  |
 | /project remove     | Removes an existing project                                             | Admin-only  |
 | /project list       | Lists all existing projects/topics                                      | Admin-only  |
+| /project view       | View full details about a specific project/topic                        | Admin-only  |
+| /project edit       | Edit various settings for a project/topic - Like changing the prefix!   | Admin-only  |
 
 # 🗓️ Planned & Work In Progress
 This bot is a hobby project for me, please note that while these features are planned, there's no solid timeline.
 - Website rewrite (It's old and ugly)
-- Staff per project
 - Customizable messages
 - Toggle to ping staff when new ticket is opened
-- Change inactivity/auto-close 
 - And so much more!
 
 # 🧰 Tech stack
@@ -60,14 +64,15 @@ This bot is a hobby project for me, please note that while these features are pl
 TicketBird is an open source, GPL-3 project. We always welcome and appreciate contributions.
 
 ## 💻 Development & Local Testing
-For development, you should have the Java 17 JDK and Docker installed (and running)
+For development, you need JDK 17+ and Docker installed.
 
 1. Fork this repository and open it in your favorite editor (IntelliJ recommended for Kotlin)
 2. Write your code and add applicable tests
-3. Build with `./gradlew clean build jibDockerBuild` (this will also build a docker image for testing)
-4. Place config in `./docker/bot-config/application.properties` and start with `docker compose up -d`
-    - You can connect to the debugger at port `5005`
-5. Create a pull request and describe your changes! <3
+3. Compile and build the docker image with `./gradlew clean build jibDockerBuild`
+4. Place config in `./docker/bot-config/application.properties`
+5. Start the bot and dependencies for testing with `docker compose up -d`
+   - You can connect to the Java debugger at port `5005`
+6. Create a pull request and describe your changes! <3
 
 # 🌐 Localization (translations)
 Please only submit localizations if you speak and/or write the language you are translating to.

--- a/README.md
+++ b/README.md
@@ -23,26 +23,28 @@ Perfect for modmail, community management, and more, TicketBird is capable of al
   - This allows you to define a user or role as staff for only a specific ticket type, allowing further customization similar to traditional RBAC.
 
 ## ⌨️ Commands
-| Command             | Description                                                             | Permissions |
-|---------------------|-------------------------------------------------------------------------|-------------|
-| /ticketbird         | Shows info about the bot                                                | Everyone    |
-| /support            | Opens a new ticket                                                      | Everyone    |
-| /close              | Closes a ticket when run in a ticket channel                            | Everyone    |
-| /hold               | Places a ticket on hold when run in a ticket channel                    | Everyone    |
-| /setup init         | Lets the bot setup by creating needed channels/categories               | Admin-only  |
-| /setup repair       | Attempts to automatically repair any configuration issues               | Admin-only  |
-| /setup use-projects | Whether to use "projects" or ticket topics to help sort tickets         | Admin-only  |
-| /setup timing       | Allows configuring the timing of TicketBird's automated actions         | Admin-only  |
-| /setup language     | Allows you to select the language for the bot to use                    | Admin-only  |
-| /staff role         | Allows users with the role to see all tickets as "TicketBird Staff"     | Admin-only  |
-| /staff add          | Add a user as being "TicketBird Staff" allowing them to see all tickets | Admin-only  |
-| /staff remove       | Remove a user as "TicketBird Staff"                                     | Admin-only  |
-| /staff list         | List all users who are currently "TicketBird staff"                     | Admin-only  |
-| /project add        | Adds a new "project" or ticket category/topic to aid with sorting       | Admin-only  |
-| /project remove     | Removes an existing project                                             | Admin-only  |
-| /project list       | Lists all existing projects/topics                                      | Admin-only  |
-| /project view       | View full details about a specific project/topic                        | Admin-only  |
-| /project edit       | Edit various settings for a project/topic - Like changing the prefix!   | Admin-only  |
+| Command             | Description                                                                               | Permissions |
+|---------------------|-------------------------------------------------------------------------------------------|-------------|
+| /ticketbird         | Shows info about the bot                                                                  | Everyone    |
+| /support            | Opens a new ticket                                                                        | Everyone    |
+| /close              | Closes a ticket when run in a ticket channel                                              | Everyone    |
+| /hold               | Places a ticket on hold when run in a ticket channel                                      | Everyone    |
+| /setup init         | Lets the bot setup by creating needed channels/categories                                 | Admin-only  |
+| /setup repair       | Attempts to automatically repair any configuration issues                                 | Admin-only  |
+| /setup use-projects | Whether to use "projects" or ticket topics to help sort tickets                           | Admin-only  |
+| /setup timing       | Allows configuring the timing of TicketBird's automated actions                           | Admin-only  |
+| /setup language     | Allows you to select the language for the bot to use                                      | Admin-only  |
+| /setup ping         | Allows modifying the default ping setting when a new ticket is opened                     | Admin-only  |
+| /setup view         | Allows viewing TicketBird's configuration in the current server                           | Admin-only  |
+| /staff role         | Allows users with the role to see all tickets as "TicketBird Staff"                       | Admin-only  |
+| /staff add          | Add a user as being "TicketBird Staff" allowing them to see all tickets                   | Admin-only  |
+| /staff remove       | Remove a user as "TicketBird Staff"                                                       | Admin-only  |
+| /staff list         | List all users who are currently "TicketBird staff"                                       | Admin-only  |
+| /project add        | Adds a new "project" or ticket category/topic to aid with sorting                         | Admin-only  |
+| /project remove     | Removes an existing project                                                               | Admin-only  |
+| /project list       | Lists all existing projects/topics                                                        | Admin-only  |
+| /project view       | View full details about a specific project/topic                                          | Admin-only  |
+| /project edit       | Edit various settings for a project/topic - Like changing prefix, staff, or ping override | Admin-only  |
 
 # 🗓️ Planned & Work In Progress
 This bot is a hobby project for me, please note that while these features are planned, there's no solid timeline.

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultGuildSettingsService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultGuildSettingsService.kt
@@ -54,6 +54,7 @@ class DefaultGuildSettingsService(
             nextId = settings.nextId,
             staff = settings.staff.asStringList(),
             staffRole = settings.staffRole?.asLong(),
+            pingOption = settings.pingOption.value,
         )).map(::GuildSettings).awaitSingle()
 
         settingsCache.put(settings.guildId.asLong(), saved)
@@ -81,6 +82,7 @@ class DefaultGuildSettingsService(
             nextId = settings.nextId,
             staff = settings.staff.asStringList(),
             staffRole = settings.staffRole?.asLong(),
+            pingOption = settings.pingOption.value,
         ).awaitSingleOrNull()
 
         settingsCache.put(settings.guildId.asLong(), settings)

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultPermissionService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultPermissionService.kt
@@ -8,6 +8,7 @@ import discord4j.rest.util.Permission
 import discord4j.rest.util.PermissionSet
 import kotlinx.coroutines.reactor.awaitSingle
 import org.dreamexposure.ticketbird.`object`.GuildSettings
+import org.dreamexposure.ticketbird.`object`.Project
 import org.springframework.beans.factory.BeanFactory
 import org.springframework.beans.factory.getBean
 import org.springframework.stereotype.Component
@@ -58,7 +59,7 @@ class DefaultPermissionService(
         Permission.USE_SLASH_COMMANDS
     )
 
-    override fun getTicketChannelOverwrites(settings: GuildSettings, creator: Snowflake): List<PermissionOverwrite> {
+    override fun getTicketChannelOverwrites(settings: GuildSettings, creator: Snowflake, project: Project?): List<PermissionOverwrite> {
         val overwrites = mutableListOf<PermissionOverwrite>()
 
         overwrites += PermissionOverwrite.forMember(creator, getTicketGrantOverrides(), PermissionSet.none())
@@ -66,7 +67,13 @@ class DefaultPermissionService(
         overwrites += settings.staff
             .map(Snowflake::of)
             .map { PermissionOverwrite.forMember(it, getTicketGrantOverrides(), PermissionSet.none()) }
-        if (settings.staffRole != null) overwrites += PermissionOverwrite.forRole(settings.staffRole!!, getTicketGrantOverrides(), PermissionSet.none())
+
+        if (project != null) {
+            overwrites += project.staffUsers.map { PermissionOverwrite.forMember(it, getTicketGrantOverrides(), PermissionSet.none()) }
+            overwrites += project.staffRoles.map { PermissionOverwrite.forRole(it, getTicketGrantOverrides(), PermissionSet.none()) }
+        }
+        if (settings.staffRole != null)
+            overwrites += PermissionOverwrite.forRole(settings.staffRole!!, getTicketGrantOverrides(), PermissionSet.none())
 
         return overwrites
     }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultProjectService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultProjectService.kt
@@ -42,6 +42,7 @@ class DefaultProjectService(
             projectPrefix = project.prefix,
             staffUsers = project.staffUsers.joinToString(","),
             staffRoles = project.staffRoles.joinToString(","),
+            pingOverride = project.pingOverride.value,
         )).map(::Project).awaitSingle()
 
         val cached = projectCache.get(project.guildId.asLong())
@@ -58,6 +59,7 @@ class DefaultProjectService(
             prefix = project.prefix,
             staffUsers = project.staffUsers.joinToString(","),
             staffRoles = project.staffRoles.joinToString(","),
+            pingOverride = project.pingOverride.value,
         ).awaitSingleOrNull()
 
         val cached = projectCache.get(project.guildId.asLong())

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultProjectService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultProjectService.kt
@@ -14,6 +14,10 @@ class DefaultProjectService(
     private val projectRepository: ProjectRepository,
     private val projectCache: ProjectCache,
 ) : ProjectService {
+
+    override suspend fun getProject(guildId: Snowflake, id: Long): Project? {
+        return getAllProjects(guildId).firstOrNull {it.id == id }
+    }
     override suspend fun getProject(guildId: Snowflake, name: String): Project? {
         return getAllProjects(guildId).firstOrNull { it.name == name }
     }
@@ -36,6 +40,8 @@ class DefaultProjectService(
             guildId = project.guildId.asLong(),
             projectName = project.name,
             projectPrefix = project.prefix,
+            staffUsers = project.staffUsers.joinToString(","),
+            staffRoles = project.staffRoles.joinToString(","),
         )).map(::Project).awaitSingle()
 
         val cached = projectCache.get(project.guildId.asLong())
@@ -50,6 +56,8 @@ class DefaultProjectService(
             guildId = project.guildId.asLong(),
             name = project.name,
             prefix = project.prefix,
+            staffUsers = project.staffUsers.joinToString(","),
+            staffRoles = project.staffRoles.joinToString(","),
         ).awaitSingleOrNull()
 
         val cached = projectCache.get(project.guildId.asLong())

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
@@ -192,6 +192,9 @@ class DefaultTicketService(
         // Create ticket channel + message
         val channel = createTicketChannel(guildId, creatorId, project, ticketNumber)
 
+
+
+        // TODO: Handle ping options
         channel.createMessage()
             .withContent(localeService.getString(settings.locale, "ticket.open.message", creatorId.asString()))
             .withEmbeds(embedBuilder.build())

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
@@ -158,14 +158,14 @@ class DefaultTicketService(
         channel.edit().withParentIdOrNull(toCategory).awaitSingleOrNull()
     }
 
-    override suspend fun createTicketChannel(guildId: Snowflake, creator: Snowflake, prefix: String?, number: Int): TextChannel {
+    override suspend fun createTicketChannel(guildId: Snowflake, creator: Snowflake, project: Project?, number: Int): TextChannel {
         val settings = settingsService.getGuildSettings(guildId)
         val guild = discordClient.getGuildById(guildId).awaitSingle()
 
-        val name = if (prefix != null) "$prefix-ticket-$number" else "ticket-$number"
+        val name = if (project != null) "${project.prefix}-ticket-$number" else "ticket-$number"
 
         return guild.createTextChannel(name)
-            .withPermissionOverwrites(permissionService.getTicketChannelOverwrites(settings, creator))
+            .withPermissionOverwrites(permissionService.getTicketChannelOverwrites(settings, creator, project))
             .withParentId(settings.awaitingCategory!!)
             .withReason(localeService.getString(settings.locale, "env.channel.ticket.create-reason"))
             .awaitSingle()
@@ -190,7 +190,7 @@ class DefaultTicketService(
         if (!info.isNullOrBlank()) embedBuilder.description(info.embedDescriptionSafe())
 
         // Create ticket channel + message
-        val channel = createTicketChannel(guildId, creatorId, project?.prefix, ticketNumber)
+        val channel = createTicketChannel(guildId, creatorId, project, ticketNumber)
 
         channel.createMessage()
             .withContent(localeService.getString(settings.locale, "ticket.open.message", creatorId.asString()))

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/DefaultTicketService.kt
@@ -10,6 +10,7 @@ import org.dreamexposure.ticketbird.TicketCache
 import org.dreamexposure.ticketbird.database.TicketData
 import org.dreamexposure.ticketbird.database.TicketRepository
 import org.dreamexposure.ticketbird.extensions.embedDescriptionSafe
+import org.dreamexposure.ticketbird.`object`.GuildSettings
 import org.dreamexposure.ticketbird.`object`.Project
 import org.dreamexposure.ticketbird.`object`.Ticket
 import org.dreamexposure.ticketbird.utils.GlobalVars
@@ -192,11 +193,45 @@ class DefaultTicketService(
         // Create ticket channel + message
         val channel = createTicketChannel(guildId, creatorId, project, ticketNumber)
 
+        // Handle ping options
+        var calculatedPingOption = when (project?.pingOverride ?: Project.PingOverride.NONE) {
+            Project.PingOverride.AUTHOR_ONLY -> GuildSettings.PingOption.AUTHOR_ONLY
+            Project.PingOverride.AUTHOR_AND_PROJECT_STAFF -> GuildSettings.PingOption.AUTHOR_AND_PROJECT_STAFF
+            Project.PingOverride.AUTHOR_AND_ALL_STAFF -> GuildSettings.PingOption.AUTHOR_AND_ALL_STAFF
+            Project.PingOverride.NONE -> settings.pingOption // Default to global setting
+        }
 
+        // Change ping setting if project is null or if there's no project staff
+        if (calculatedPingOption == GuildSettings.PingOption.AUTHOR_AND_PROJECT_STAFF && (project == null || (project.staffRoles.isEmpty() && project.staffUsers.isEmpty())))
+            calculatedPingOption = GuildSettings.PingOption.AUTHOR_ONLY // No project, can't be project
 
-        // TODO: Handle ping options
+        // Get computed message
+        val message = if (calculatedPingOption != GuildSettings.PingOption.AUTHOR_ONLY) {
+            val pings = mutableListOf<String>()
+
+            if (calculatedPingOption == GuildSettings.PingOption.AUTHOR_AND_PROJECT_STAFF) {
+                pings += project!!.staffUsers.map { "<@${it.asString()}>" }
+                pings += project!!.staffRoles.map { "<@&${it.asString()}>" }
+            } else if (calculatedPingOption == GuildSettings.PingOption.AUTHOR_AND_ALL_STAFF) {
+                pings += settings.staff.map(Snowflake::of).map { "<@${it.asString()}>" }
+                if (settings.staffRole != null) pings += "<@&${settings.staffRole!!.asString()}>"
+
+                if (project != null) {
+                    pings += project.staffUsers.map { "<@${it.asString()}>" }
+                    pings += project.staffRoles.map { "<@&${it.asString()}>" }
+                }
+            }
+
+            val pingString = pings.joinToString(", ")
+
+            localeService.getString(settings.locale, "ticket.open.message.ping-author-staff", creatorId.asString(), pingString)
+        } else {
+            localeService.getString(settings.locale, "ticket.open.message.ping-author-only", creatorId.asString())
+        }
+
+        // Create message
         channel.createMessage()
-            .withContent(localeService.getString(settings.locale, "ticket.open.message", creatorId.asString()))
+            .withContent(message)
             .withEmbeds(embedBuilder.build())
             .withComponents(*componentService.getTicketMessageComponents(settings))
             .awaitSingle()

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/PermissionService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/PermissionService.kt
@@ -4,6 +4,7 @@ import discord4j.common.util.Snowflake
 import discord4j.core.`object`.PermissionOverwrite
 import discord4j.rest.util.PermissionSet
 import org.dreamexposure.ticketbird.`object`.GuildSettings
+import org.dreamexposure.ticketbird.`object`.Project
 
 interface PermissionService {
 
@@ -15,7 +16,7 @@ interface PermissionService {
 
     fun getTicketGrantOverrides(): PermissionSet
 
-    fun getTicketChannelOverwrites(settings: GuildSettings, creator: Snowflake): List<PermissionOverwrite>
+    fun getTicketChannelOverwrites(settings: GuildSettings, creator: Snowflake, project: Project?): List<PermissionOverwrite>
 
     fun hasRequiredElevatedPermissions(memberPermissions: PermissionSet): Boolean
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/ProjectService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/ProjectService.kt
@@ -4,6 +4,8 @@ import discord4j.common.util.Snowflake
 import org.dreamexposure.ticketbird.`object`.Project
 
 interface ProjectService {
+
+    suspend fun getProject(guildId: Snowflake, id: Long): Project?
     suspend fun getProject(guildId: Snowflake, name: String): Project?
 
     suspend fun getAllProjects(guildId: Snowflake): List<Project>

--- a/src/main/kotlin/org/dreamexposure/ticketbird/business/TicketService.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/business/TicketService.kt
@@ -28,7 +28,7 @@ interface TicketService {
 
     suspend fun moveTicket(guildId: Snowflake, channelId: Snowflake, toCategory: Snowflake, withActivity: Boolean = true)
 
-    suspend fun createTicketChannel(guildId: Snowflake, creator: Snowflake, prefix: String? = null, number: Int): TextChannel
+    suspend fun createTicketChannel(guildId: Snowflake, creator: Snowflake, project: Project?, number: Int): TextChannel
 
     suspend fun createNewTicketFull(guildId: Snowflake, creatorId: Snowflake, project: Project? = null, info: String?): Ticket
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/command/ProjectCommand.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/command/ProjectCommand.kt
@@ -211,17 +211,17 @@ class ProjectCommand(
             if (staffRoles.contains(staffRole)) staffRoles.remove(staffRole)
             else staffRoles.add(staffRole)
         }
-        // TODO: Add ping override
         projectService.updateProject(project.copy(
             prefix = prefix,
             staffUsers = staffUsers,
             staffRoles = staffRoles,
             pingOverride = pingOverride,
         ))
+        val updatedProject = projectService.getProject(settings.guildId, project.id)!!
 
         // Return with project view embed
         event.createFollowup(localeService.getString(settings.locale, "command.project.edit.success"))
-            .withEmbeds(viewEmbed(settings, project))
+            .withEmbeds(viewEmbed(settings, updatedProject))
             .withEphemeral(ephemeral)
             .awaitSingleOrNull()
     }
@@ -324,7 +324,7 @@ class ProjectCommand(
 
         // Staff roles
         if (project.staffRoles.isNotEmpty()) {
-            val mentions = project.staffRoles.joinToString("\n") { "<@${it.asString()}>" }
+            val mentions = project.staffRoles.joinToString("\n") { "<@&${it.asString()}>" }
             builder.addField(
                 localeService.getString(settings.locale, "embed.project-view.field.staff-roles"),
                 mentions.embedFieldSafe(),

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsData.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsData.kt
@@ -30,4 +30,5 @@ data class GuildSettingsData(
 
     val staff: String,
     val staffRole: Long?,
+    val pingOption: Int,
 )

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsRepository.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/GuildSettingsRepository.kt
@@ -26,7 +26,8 @@ interface GuildSettingsRepository: R2dbcRepository<GuildSettingsData, Long> {
             static_message = :staticMessage,
             next_id = :nextId,
             staff = :staff,
-            staff_role = :staffRole
+            staff_role = :staffRole,
+            ping_option = :pingOption
         WHERE guild_id = :guildId
     """)
     fun updateByGuildId(
@@ -49,6 +50,7 @@ interface GuildSettingsRepository: R2dbcRepository<GuildSettingsData, Long> {
         nextId: Int,
         staff: String,
         staffRole: Long?,
+        pingOption: Int,
     ): Mono<Int>
 
     fun deleteByGuildId(guildId: Long): Mono<Void>

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectData.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectData.kt
@@ -10,4 +10,6 @@ data class ProjectData(
     val guildId: Long,
     val projectName: String,
     val projectPrefix: String,
+    val staffUsers: String?,
+    val staffRoles: String?,
 )

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectData.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectData.kt
@@ -12,4 +12,5 @@ data class ProjectData(
     val projectPrefix: String,
     val staffUsers: String?,
     val staffRoles: String?,
+    val pingOverride: Int,
 )

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectRepository.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectRepository.kt
@@ -17,7 +17,8 @@ interface ProjectRepository: R2dbcRepository<ProjectData, Long> {
         SET project_prefix = :prefix,
             project_name = :name,
             staff_users = :staffUsers,
-            staff_roles = :staffRoles
+            staff_roles = :staffRoles,
+            ping_override = :pingOverride
         WHERE guild_id = :guildId
             AND id = :id
     """)
@@ -28,5 +29,6 @@ interface ProjectRepository: R2dbcRepository<ProjectData, Long> {
         name: String,
         staffUsers: String?,
         staffRoles: String?,
+        pingOverride: Int,
     ): Mono<Int>
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectRepository.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/database/ProjectRepository.kt
@@ -15,7 +15,9 @@ interface ProjectRepository: R2dbcRepository<ProjectData, Long> {
     @Query("""
         UPDATE projects
         SET project_prefix = :prefix,
-            project_name = :name
+            project_name = :name,
+            staff_users = :staffUsers,
+            staff_roles = :staffRoles
         WHERE guild_id = :guildId
             AND id = :id
     """)
@@ -24,5 +26,7 @@ interface ProjectRepository: R2dbcRepository<ProjectData, Long> {
         guildId: Long,
         prefix: String,
         name: String,
+        staffUsers: String?,
+        staffRoles: String?,
     ): Mono<Int>
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/interaction/ProjectCommandAutoComplete.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/interaction/ProjectCommandAutoComplete.kt
@@ -12,11 +12,12 @@ import org.springframework.stereotype.Component
 class ProjectCommandAutoComplete(
     private val projectService: ProjectService,
 ) : InteractionHandler<ChatInputAutoCompleteEvent> {
-    override val ids = arrayOf("project.name", "support.topic", "topic.topic")
+    override val ids = arrayOf("project.name", "project.project", "support.topic", "topic.topic")
 
     override suspend fun handle(event: ChatInputAutoCompleteEvent, settings: GuildSettings) {
         when ("${event.commandName}.${event.focusedOption.name}") {
-            "project.name" -> projectName(event)
+            "project.name",
+            "project.project" -> projectName(event)
             "support.topic",
             "topic.topic" -> checkUsingFirst(event, settings)
             else -> event.respondWithSuggestions(listOf()).awaitSingleOrNull()

--- a/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/object/GuildSettings.kt
@@ -31,6 +31,7 @@ data class GuildSettings(
     var nextId: Int = 1,
     val staff: MutableList<String> = CopyOnWriteArrayList(),
     var staffRole: Snowflake? = null,
+    var pingOption: PingOption = PingOption.AUTHOR_ONLY,
 ) {
     constructor(data: GuildSettingsData) : this(
         guildId = Snowflake.of(data.guildId),
@@ -53,6 +54,7 @@ data class GuildSettings(
         nextId = data.nextId,
         staff = data.staff.listFromDb(),
         staffRole = data.staffRole?.toSnowflake(),
+        pingOption = PingOption.valueOf(data.pingOption)
     )
 
     fun hasRequiredIdsSet(): Boolean {
@@ -62,5 +64,16 @@ data class GuildSettings(
             && closeCategory != null
             && supportChannel != null
             && staticMessage != null
+    }
+
+    enum class PingOption(val value: Int, val localeEntry: String) {
+        AUTHOR_ONLY(1, "env.ping-option.author"),
+        AUTHOR_AND_PROJECT_STAFF(2, "env.ping-option.author-project-staff"),
+        AUTHOR_AND_ALL_STAFF(3, "env.ping-option.author-all-staff");
+
+        companion object {
+            fun valueOf(value: Int) = values().first { it.value == value }
+
+        }
     }
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/object/Project.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/object/Project.kt
@@ -7,15 +7,25 @@ data class Project(
     val id: Long = 0,
 
     val guildId: Snowflake,
-
     val name: String,
-
     val prefix: String,
+    val staffUsers: List<Snowflake> = listOf(),
+    val staffRoles: List<Snowflake> = listOf(),
 ) {
     constructor(data: ProjectData): this(
         id = data.id!!,
         guildId = Snowflake.of(data.guildId),
         name = data.projectName,
         prefix = data.projectPrefix,
+        staffUsers = data.staffUsers
+            ?.split(",")
+            ?.filter(String::isNullOrEmpty)
+            ?.map(Snowflake::of)
+            ?.toList() ?: listOf(),
+        staffRoles = data.staffRoles
+            ?.split(",")
+            ?.filter(String::isNullOrEmpty)
+            ?.map(Snowflake::of)
+            ?.toList() ?: listOf(),
     )
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/object/Project.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/object/Project.kt
@@ -11,6 +11,7 @@ data class Project(
     val prefix: String,
     val staffUsers: List<Snowflake> = listOf(),
     val staffRoles: List<Snowflake> = listOf(),
+    val pingOverride: PingOverride = PingOverride.NONE,
 ) {
     constructor(data: ProjectData): this(
         id = data.id!!,
@@ -27,5 +28,18 @@ data class Project(
             ?.filter(String::isNullOrEmpty)
             ?.map(Snowflake::of)
             ?.toList() ?: listOf(),
+        pingOverride = PingOverride.valueOf(data.pingOverride)
     )
+
+
+    enum class PingOverride(val value: Int, val localeEntry: String) {
+        NONE(1, "env.ping-override.none"),
+        AUTHOR_ONLY(2, "env.ping-option.author"),
+        AUTHOR_AND_PROJECT_STAFF(3, "env.ping-option.author-project-staff"),
+        AUTHOR_AND_ALL_STAFF(4, "env.ping-option.author-all-staff");
+
+        companion object {
+            fun valueOf(value: Int) = values().first { it.value == value }
+        }
+    }
 }

--- a/src/main/kotlin/org/dreamexposure/ticketbird/service/StatusChanger.kt
+++ b/src/main/kotlin/org/dreamexposure/ticketbird/service/StatusChanger.kt
@@ -22,14 +22,15 @@ class StatusChanger(private val client: GatewayDiscordClient) : ApplicationRunne
     private val index = AtomicInteger(0)
 
     private val statuses = listOf(
-        "/ticketbird for info & help",
-        "Do you know what a square is?",
-        "Version {version}",
-        "Now supports Slash Commands!",
-        "Trans rights are human rights",
-        "Sorting tickets in {guild_count} guilds!",
-        "Proudly written in Kotlin using Discord4J",
-        "Slava Ukraini!",
+            "/ticketbird for info & help",
+            "Do you know what a square is?",
+            "Version {version}",
+            "Now supports Slash Commands!",
+            "Trans rights are human rights",
+            "Sorting tickets in {guild_count} guilds!",
+            "Now supports staff per-topic!",
+            "Proudly written in Kotlin using Discord4J",
+            "Slava Ukraini!",
     )
 
     private fun update() = mono {
@@ -42,7 +43,7 @@ class StatusChanger(private val client: GatewayDiscordClient) : ApplicationRunne
 
         //Get status we want to change to
         var status = statuses[currentIndex]
-            .replace("{version}", GitProperty.TICKETBIRD_VERSION.value)
+                .replace("{version}", GitProperty.TICKETBIRD_VERSION.value)
 
         if (status.contains("{guild_count}")) {
             val count = client.guilds.count().awaitSingle()
@@ -55,9 +56,9 @@ class StatusChanger(private val client: GatewayDiscordClient) : ApplicationRunne
 
     override fun run(args: ApplicationArguments?) {
         Flux.interval(Duration.ofMinutes(5))
-            .flatMap { update() }
-            .doOnError { LOGGER.error(DEFAULT, "StatusChanger | Processor failure ", it) }
-            .onErrorResume { Mono.empty() }
-            .subscribe()
+                .flatMap { update() }
+                .doOnError { LOGGER.error(DEFAULT, "StatusChanger | Processor failure ", it) }
+                .onErrorResume { Mono.empty() }
+                .subscribe()
     }
 }

--- a/src/main/resources/commands/project.json
+++ b/src/main/resources/commands/project.json
@@ -14,14 +14,16 @@
           "name": "name",
           "description": "The name of the new project.",
           "required": true,
-          "max_length": 100
+          "max_length": 100,
+          "min_length": 1
         },
         {
           "type": 3,
           "name": "prefix",
-          "description": "A prefix to help identify tickets for this project. 16 characters max, alphanumeric allowed.",
+          "description": "A prefix to help identify tickets for this project. 16 characters max, alphanumeric allowed",
           "required": true,
-          "max_length": 16
+          "max_length": 16,
+          "min_length": 1
         }
       ]
     },
@@ -55,6 +57,42 @@
           "description": "The project to view",
           "required": true,
           "autocomplete": true
+        }
+      ]
+    },
+    {
+      "type": 1,
+      "name": "edit",
+      "description": "Edit a project",
+      "options": [
+        {
+          "type": 3,
+          "name": "project",
+          "description": "The project to edit",
+          "required": true,
+          "autocomplete": true
+        },
+        {
+          "type": 3,
+          "name": "prefix",
+          "description": "The new prefix for the project. 16 characters max, alphanumeric allowed",
+          "max_length": 16,
+          "min_length": 1
+        },
+        {
+          "type": 6,
+          "name": "staff-user",
+          "description": "A user to add or remove as staff on this project"
+        },
+        {
+          "type": 8,
+          "name": "staff-role",
+          "description": "A role to add or remove as staff on this project"
+        },
+        {
+          "type": 5,
+          "name": "remove-all-staff",
+          "description": "Whether to remove all existing staff from this project (default: false)"
         }
       ]
     }

--- a/src/main/resources/commands/project.json
+++ b/src/main/resources/commands/project.json
@@ -43,6 +43,20 @@
       "type": 1,
       "name": "list",
       "description": "Lists all projects"
+    },
+    {
+      "type": 1,
+      "name": "view",
+      "description": "View info about a specific project",
+      "options": [
+        {
+          "type": 3,
+          "name": "name",
+          "description": "The project to view",
+          "required": true,
+          "autocomplete": true
+        }
+      ]
     }
   ]
 }

--- a/src/main/resources/commands/project.json
+++ b/src/main/resources/commands/project.json
@@ -80,6 +80,29 @@
           "min_length": 1
         },
         {
+          "type": 4,
+          "name": "ping-override",
+          "description": "Override global ping settings for this project",
+          "choices": [
+            {
+              "name": "No override - Use global ping setting (default)",
+              "value": 1
+            },
+            {
+              "name": "Ping author only",
+              "value": 2
+            },
+            {
+              "name": "Ping author and project staff",
+              "value": 3
+            },
+            {
+              "name": "Ping author and all staff",
+              "value": 4
+            }
+          ]
+        },
+        {
           "type": 6,
           "name": "staff-user",
           "description": "A user to add or remove as staff on this project"

--- a/src/main/resources/commands/setup.json
+++ b/src/main/resources/commands/setup.json
@@ -73,6 +73,33 @@
           "max_value": 999
         }
       ]
+    },
+    {
+      "type": 1,
+      "name": "ping",
+      "description": "Modify the global ping settings when a ticket is opened. May be overridden on the project-level",
+      "options": [
+        {
+          "type": 4,
+          "name": "setting",
+          "description": "The ping setting to use globally",
+          "required": true,
+          "choices": [
+            {
+              "name": "Ping author only (default)",
+              "value": 1
+            },
+            {
+              "name": "Ping author and project staff",
+              "value": 2
+            },
+            {
+              "name": "Ping author and all staff",
+              "value": 3
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src/main/resources/commands/setup.json
+++ b/src/main/resources/commands/setup.json
@@ -100,6 +100,11 @@
           ]
         }
       ]
+    },
+    {
+      "type": 1,
+      "name": "view",
+      "description": "Allows viewing TicketBird's configuration in this server"
     }
   ]
 }

--- a/src/main/resources/db/migration/V14__Staff_RBAC.sql
+++ b/src/main/resources/db/migration/V14__Staff_RBAC.sql
@@ -1,0 +1,7 @@
+ALTER TABLE projects
+    ADD COLUMN staff_users LONGTEXT NULL
+    AFTER project_prefix;
+
+ALTER TABLE projects
+    ADD COLUMN staff_roles LONGTEXT NULL
+    AFTER staff_users;

--- a/src/main/resources/db/migration/V15__Ping_Options.sql
+++ b/src/main/resources/db/migration/V15__Ping_Options.sql
@@ -1,0 +1,8 @@
+ALTER TABLE guild_settings
+    ADD COLUMN ping_option SMALLINT NOT NULL DEFAULT 1
+        AFTER staff_role;
+
+ALTER TABLE projects
+    ADD COLUMN ping_override SMALLINT NOT NULL DEFAULT 1
+        AFTER staff_roles;
+

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -174,3 +174,5 @@ command.project.add.success=Project successfully created.
 command.project.remove.not-found=A project with that name was not found.
 command.project.remove.success=Project successfully removed.
 command.project.view.not-found=A project with that name was not found.
+command.project.edit.not-found=A project with that name was not found and could not be edited.
+command.project.edit.success=Project successfully edited.

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -24,7 +24,11 @@ env.ping-option.author-all-staff=ping author and all staff
 env.ping-override.none=No override, using global setting
 
 # Ticket
-ticket.open.message=<@{0}> has opened a new ticket!
+ticket.open.message.ping-author-only=<@{0}> has opened a new ticket!
+ticket.open.message.ping-author-staff=<@{0}> has opened a new ticket! \n\n\
+  {1} will be available to assist you shortly.
+
+
 ticket.reopen.everyone=@everyone this ticket has been reopened!
 ticket.reopen.creator=<@{0}> this ticket has been reopened!
 ticket.hold.creator=<@{0}> this ticket has been placed on hold until a staff member is available to assist you! \
@@ -63,6 +67,26 @@ embed.info.field.uptime=Shard Uptime
 embed.info.field.links=Links
 embed.info.field.links.value=__[Commands]({0})__ | __[Support]({1})__ | __[Invite]({2})__ | __[Patreon]({3})__
 embed.info.footer=Help support the bot by becoming a patron today!
+
+embed.settings.title=TicketBird Configuration
+embed.settings.field.categories=Managed Categories
+embed.settings.field.categories.not-init=Not yet initialized. \n\
+  Use `/setup init` to get started.
+embed.settings.field.support-channel=Support Request Channel
+embed.settings.field.support-channel.not-init=Not yet initialized. \n\
+  Use `/setup init` to get started.
+embed.settings.field.timing=Bot Timings
+embed.settings.field.timing.value=Open tickets will be automatically closed after __**{0}**__ of inactivity. \n\
+  Closed tickets will be automatically deleted after __**{1}**__.
+embed.settings.field.language=Language
+embed.settings.field.use-projects=Use Projects
+embed.settings.field.ping=Ping On Ticket Create
+embed.settings.field.note=\u26A0 Notes
+embed.settings.field.note.disabled-with-any=Project use is currently disabled. \n\
+  Use `/setup use-projects` to allow users to select a project when opening a ticket.
+embed.settings.field.note.enabled-and-none=Project use is currently enabled but there are no projects. \n\
+  Use `/setup use-projects` to allow users to open tickets without needing to select a project.
+embed.settings.footer=Use the /setup command to edit these settings
 
 embed.projects.title=All Projects
 embed.projects.field.prefix.value=Prefix: `{0}`
@@ -150,7 +174,7 @@ command.setup.language.success=Successfully changed the default language!
 command.setup.use-projects.success.true=Successfully enabled projects! \
   If no projects exist yet, users will not be able to open tickets. Existing tickets will not be modified. \n\n\
   Use `/project add` to add a new project.
-command.setup.use-projects.success.false=Successfully disabled projects!\
+command.setup.use-projects.success.false=Successfully disabled projects! \
   Users will not need to select a project when opening a ticket. Existing projects and tickets will not be modified.
 command.setup.timing.error.duration-zero=This timing cannot be set to 0. Make sure it's set to at least 1 hour.
 command.setup.timing.error.action-not-found=An action with that name was not found. Perhaps there was a typo?

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -67,6 +67,20 @@ embed.projects.field.note.disabled-with-any=Project use is currently disabled. \
   Use `/setup use-projects` to allow users to select a project when opening a ticket.
 embed.projects.field.note.enabled-and-none=Project use is currently enabled but there are no projects. \n\
   Use `/setup use-projects` to allow users to open tickets without needing to select a project.
+embed.projects.footer=Use /project view to view more info about a project.
+
+embed.project-view.field.prefix=Prefix
+embed.project-view.field.example=Example Channel Name
+embed.project-view.field.staff-users=Staff Users
+embed.project-view.field.staff-users.none=No project-level staff users. \n\
+  Use `/project edit` to add staff for this project.
+embed.project-view.field.staff-roles=Staff Roles
+embed.project-view.field.staff-roles.none=No project-level staff roles. \n\
+  Use `/project edit` to add staff for this project.
+embed.project-view.field.note=\u26A0 Notes
+embed.project-view.field.note.disabled-with-any=Project use is currently disabled. \n\
+  Use `/setup use-projects` to allow users to select a project when opening a ticket.
+embed.project-view.footer=Use /project edit to modify the above info.
 
 
 # Buttons
@@ -94,23 +108,28 @@ auto-complete.setup.actions.auto-delete=Auto Delete Closed Ticket (Current: {0})
 # Commands
 command.dm-not-supported=Commands not supported in DMs.
 
+# Support command
 command.support.topic.not-found=That topic was not found. Use the dropdown below to select a topic.
 
+# Close command
 command.close.not-ticket=This channel is not a ticket channel. If this is a mistake, \
   you can manually close this ticket by deleting the channel.
 command.close.already-closed=This ticket has already been closed.
 command.close.success=Successfully closed ticket.
 
+# Hold command
 command.hold.not-ticket=This channel is not a ticket channel. If this is a mistake, \
   you can create a new ticket and delete this channel.
 command.hold.already-held=This ticket has already been put on hold.
 command.hold.success=Successfully placed ticket on hold.
 
+# Topic command
 command.topic.not-ticket=This channel is not a ticket channel. If this is a mistake, \
   you can create a new ticket and delete this channel.
 command.topic.not-found=That topic was not found, cannot change this ticket's topic.
 command.topic.success=Successfully changed ticket topic to `{0}`
 
+# Staff command
 command.staff.role.success=TicketBird staff role successfully updated.
 command.staff.add.already=That user is already a TicketBird Staff Member for this server. \
   Remove them with `/staff remove`
@@ -118,6 +137,7 @@ command.staff.add.success=Successfully added <@{0}> as a TicketBird Staff Member
 command.staff.remove.not=That user is not a TicketBird Staff Member for this server. Add them with `/staff add`
 command.staff.remove.success=Successfully removed <@{0}> as a ticketBird Staff Member for this server!
 
+# Setup command
 command.setup.missing-perms=This command requires the `Manage Server` permission. \
   If this is a mistake, contact a server administrator.
 command.setup.bot-missing-perms=TicketBird is missing the following permissions at the server level: \```fix\n{0}\n```
@@ -144,6 +164,7 @@ command.setup.repair.no-issue-detected=TicketBird did not detect any issues. If 
 command.setup.repair.success=Successfully repaired TicketBird setup. If something is still not working, please reach \
   out to the developers in the support server (linked in `/ticketbird`)
 
+# Project command
 command.project.missing-perms=This command requires the `Manage Server` permission. \
   If this is a mistake, contact a server administrator.
 command.project.add.exists=A project with that name already exists.
@@ -152,3 +173,4 @@ command.project.add.limit-reached=The project limit of 25 has already been reach
 command.project.add.success=Project successfully created.
 command.project.remove.not-found=A project with that name was not found.
 command.project.remove.success=Project successfully removed.
+command.project.view.not-found=A project with that name was not found.

--- a/src/main/resources/locale/values.properties
+++ b/src/main/resources/locale/values.properties
@@ -18,6 +18,10 @@ env.channel.support.name=support-request
 env.channel.support.topic=Need help with something? Open a new ticket by clicking the button in this channel. \
   No commands or messages needed.
 env.channel.ticket.create-reason=New ticket created
+env.ping-option.author=ping author only
+env.ping-option.author-project-staff=ping author and project staff
+env.ping-option.author-all-staff=ping author and all staff
+env.ping-override.none=No override, using global setting
 
 # Ticket
 ticket.open.message=<@{0}> has opened a new ticket!
@@ -71,6 +75,7 @@ embed.projects.footer=Use /project view to view more info about a project.
 
 embed.project-view.field.prefix=Prefix
 embed.project-view.field.example=Example Channel Name
+embed.project-view.field.ping-override=Ping Override
 embed.project-view.field.staff-users=Staff Users
 embed.project-view.field.staff-users.none=No project-level staff users. \n\
   Use `/project edit` to add staff for this project.
@@ -151,6 +156,7 @@ command.setup.timing.error.duration-zero=This timing cannot be set to 0. Make su
 command.setup.timing.error.action-not-found=An action with that name was not found. Perhaps there was a typo?
 command.setup.timing.success.auto-close=Tickets will now be automatically closed after {0} of inactivity.
 command.setup.timing.success.auto-delete=Closed tickets will now be automatically deleted after {0}.
+command.setup.ping.success=Successfully set TicketBird to {0} when a new ticket is opened.
 command.setup.init.already=TicketBird has already been initialized. You do not need to run this command again. \n\n\
   If you accidentally deleted a category or the support channel, you can use `/setup repair`
 command.setup.init.success=TicketBird Setup Complete! \n\


### PR DESCRIPTION
Adds ability to add staff-per-project, allow pinging specific staff on ticket open, and adds a command to allow viewing TicketBird bot configuration via command.

Closes #19 and closes #14 

